### PR TITLE
TypeScript errors from missing typings and imports.

### DIFF
--- a/src/pages/nested-form-example-page/components/form-1/form-1-view.tsx
+++ b/src/pages/nested-form-example-page/components/form-1/form-1-view.tsx
@@ -15,7 +15,7 @@ type Form1ViewProps = {
 }
 const Form1View: React.FC<Form1ViewProps> = (props) => {
   const { profile, onSubmit, name } = props
-  const { handleSubmit, watch, register } = useNestedForm({
+  const { handleSubmit, watch, register } = useNestedForm<Form1ViewProps>({
     register: props.register,
     defaultValues: { profile },
   })

--- a/src/pages/nested-form-example-page/components/form-2/form-2-view.tsx
+++ b/src/pages/nested-form-example-page/components/form-2/form-2-view.tsx
@@ -15,7 +15,7 @@ type Form2ViewProps = {
 }
 const Form2View: React.FC<Form2ViewProps> = (props) => {
   const { info, onSubmit, name } = props
-  const { handleSubmit, watch, register } = useNestedForm({
+  const { handleSubmit, watch, register } = useNestedForm<Form2ViewProps>({
     register: props.register,
     defaultValues: { info },
   })

--- a/src/utilities/use-form.ts
+++ b/src/utilities/use-form.ts
@@ -1,6 +1,12 @@
 import * as React from 'react'
-import { useForm as useHookForm, UseFormOptions, UseFormMethods } from 'react-hook-form'
-import { FieldValues, UnpackNestedValue, FieldName } from 'react-hook-form/dist/types/form'
+import {
+  useForm as useHookForm,
+  UseFormOptions,
+  UseFormMethods,
+  FieldValues,
+  UnpackNestedValue,
+  FieldName,
+} from 'react-hook-form'
 import { getNamesForObject } from './get-names-for-object'
 
 export function flattenNames(obj: object | string): Array<string> {


### PR DESCRIPTION
Fixed TypeScript errors. appearing while setting up the project on a Windows computer. 

Errors came from missing type arguments and from a erroneous import.