### PR TITLE
Fixing error query devtools, "queries" not found by

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint-staged": "^10.4.0",
     "prettier": "^2.1.2",
     "react-is": "^17.0.1",
-    "react-query-devtools": "^2.6.3",
+    "react-query-devtools": "3.0.0",
     "rimraf": "^3.0.2",
     "serve": "^11.3.2",
     "tailwindcss": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9225,10 +9225,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-react-query-devtools@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/react-query-devtools/-/react-query-devtools-2.6.3.tgz#f7c982839d4b0001cee4d5ddfa826493c2f6341f"
-  integrity sha512-pSvWq5Q8zgIP7QbF0+4BerCHLaLn5HPzce7sIXYqz4XEizcYJHkJtcrAwn6bUkCu5JmAt1Y7fViQtZwOIG2SYA==
+react-query-devtools@3.0.0:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-query-devtools/-/react-query-devtools-3.0.0-beta.1.tgz#0eab3925c7f219887baed1bb037f0a8b6ee530cc"
+  integrity sha512-Yef2y/YQLO1t+zu0E+C/sZQDqT1o8DBdX+z0cmpJmPuNMYsT7ZE3rJY18sp0GCzxZVB05Rku1GKtQKAVUjz8og==
   dependencies:
     match-sorter "^4.1.0"
 


### PR DESCRIPTION
Fixing this error by updating version of query-devtools to "3.0.0"

<img width="1680" alt="Snipaste_2021-08-11_12-03-06" src="https://user-images.githubusercontent.com/18025983/128968154-8d9bda5f-da94-4603-b4ac-c149262918af.png">
